### PR TITLE
Always pass proper parent to Xonomy.xml2js() function

### DIFF
--- a/xonomy.css
+++ b/xonomy.css
@@ -153,6 +153,9 @@
 
 /*When the pop-up box functions as menu or picker*/
 #xonomyBubble.nerd #xonomyBubbleContent div.menu { margin: -5px; max-height: 250px; overflow-y: auto; white-space: nowrap; }
+#xonomyBubble.nerd #xonomyBubbleContent div.submenu { position: absolute; display: none; }
+#xonomyBubble.nerd #xonomyBubbleContent div.menuItem:hover div { position: relative; padding: 4px; display: block; }
+#xonomyBubble.nerd #xonomyBubbleContent div.submenu div.menuItem:hover { background: #fbf4b8; }
 #xonomyBubble.nerd #xonomyBubbleContent div.menuItem { padding: 8px 20px 7px 10px; border-top: 1px solid #dddddd; cursor: pointer; margin-top: -1px; }
 #xonomyBubble.nerd #xonomyBubbleContent span.techno { font-family: monospace; font-size: 0.9rem; }
 #xonomyBubble.nerd #xonomyBubbleContent span.techno span.punc {color: #669acc; }
@@ -348,6 +351,9 @@
 
 /*When the pop-up box functions as menu or picker*/
 #xonomyBubble.laic #xonomyBubbleContent div.menu { margin: -10px; max-height: 250px; overflow-y: auto; white-space: nowrap; }
+#xonomyBubble.laic #xonomyBubbleContent div.submenu { position: absolute; display: none; }
+#xonomyBubble.laic #xonomyBubbleContent div.menuItem:hover div { position: relative; padding: 4px; display: block; }
+#xonomyBubble.laic #xonomyBubbleContent div.submenu div.menuItem:hover { background: #fbf4b8; }
 #xonomyBubble.laic #xonomyBubbleContent div.menuItem { padding: 10px 20px 10px 10px; border-top: 1px solid #dddddd; cursor: pointer; margin-top: -1px; }
 #xonomyBubble.laic #xonomyBubbleContent .techno { font-family: monospace; font-size: 0.85rem; color: #444444; }
 #xonomyBubble.laic #xonomyBubbleContent .techno span.atName { font-family: Verdana, sans-serif; font-weight: bold; color: #6385bf; }

--- a/xonomy.css
+++ b/xonomy.css
@@ -378,4 +378,3 @@
 .xonomy .wyc { display: inline-block; background-image: url(loader.gif); background-position: center center; background-repeat: no-repeat; width: 30px; height: 10px; }
 .xonomy .inlinecaption a { color: inherit; text-decoration: none; }
 .xonomy .inlinecaption a:hover {color: #2d4ea1;}
-

--- a/xonomy.js
+++ b/xonomy.js
@@ -651,6 +651,7 @@ Xonomy.wrap=function(htmlID, param) {
 	Xonomy.clickoff();
 	var xml=param.template;
 	var ph=param.placeholder;
+	var jsElement=Xonomy.harvestElement(document.getElementById(htmlID));
 	if(Xonomy.textFromID==Xonomy.textTillID) { //abc --> a<XYZ>b</XYZ>c
 		var jsOld=Xonomy.harvestText(document.getElementById(Xonomy.textFromID));
 		var txtOpen=jsOld.value.substring(0, Xonomy.textFromIndex);
@@ -659,7 +660,7 @@ Xonomy.wrap=function(htmlID, param) {
 		xml=xml.replace(ph, Xonomy.xmlEscape(txtMiddle));
 		var html="";
 		html+=Xonomy.renderText({type: "text", value: txtOpen});
-		html+=Xonomy.renderElement(Xonomy.xml2js(xml));
+		html+=Xonomy.renderElement(Xonomy.xml2js(xml, jsElement));
 		html+=Xonomy.renderText({type: "text", value: txtClose});
 		$("#"+Xonomy.textFromID).replaceWith(html);
 	} else { //ab<...>cd --> a<XYZ>b<...>c</XYZ>d
@@ -679,7 +680,7 @@ Xonomy.wrap=function(htmlID, param) {
 		$("#"+Xonomy.textTillID).remove();
 		var html="";
 		html+=Xonomy.renderText({type: "text", value: txtOpen});
-		html+=Xonomy.renderElement(Xonomy.xml2js(xml));
+		html+=Xonomy.renderElement(Xonomy.xml2js(xml, jsElement));
 		html+=Xonomy.renderText({type: "text", value: txtClose});
 		$("#"+Xonomy.textFromID).replaceWith(html);
 	}
@@ -1078,7 +1079,8 @@ Xonomy.newAttribute=function(htmlID, parameter) {
 };
 Xonomy.newElementChild=function(htmlID, parameter) {
 	Xonomy.clickoff();
-	var html=Xonomy.renderElement(Xonomy.xml2js(parameter));
+	var jsElement=Xonomy.harvestElement(document.getElementById(htmlID));
+	var html=Xonomy.renderElement(Xonomy.xml2js(parameter, jsElement));
 	var $html=$(html).hide();
 	$("#"+htmlID+" > .children").append($html);
 	Xonomy.plusminus(htmlID, true);
@@ -1120,7 +1122,8 @@ Xonomy.elementReorder=function(htmlID){
 };
 Xonomy.newElementBefore=function(htmlID, parameter) {
 	Xonomy.clickoff();
-	var html=Xonomy.renderElement(Xonomy.xml2js(parameter));
+	var jsElement=Xonomy.harvestElement(document.getElementById(htmlID));
+	var html=Xonomy.renderElement(Xonomy.xml2js(parameter, jsElement.parent()));
 	var $html=$(html).hide();
 	$("#"+htmlID).before($html);
 	Xonomy.changed();
@@ -1128,7 +1131,8 @@ Xonomy.newElementBefore=function(htmlID, parameter) {
 };
 Xonomy.newElementAfter=function(htmlID, parameter) {
 	Xonomy.clickoff();
-	var html=Xonomy.renderElement(Xonomy.xml2js(parameter));
+	var jsElement=Xonomy.harvestElement(document.getElementById(htmlID));
+	var html=Xonomy.renderElement(Xonomy.xml2js(parameter, jsElement.parent()));
 	var $html=$(html).hide();
 	$("#"+htmlID).after($html);
 	Xonomy.changed();
@@ -1154,8 +1158,8 @@ Xonomy.editRaw=function(htmlID, parameter) {
 	Xonomy.answer=function(val) {
 		var jsNewElement;
 		if(parameter.toJs) jsNewElement=parameter.toJs(val, jsElement);
-		else if(parameter.toXml) jsNewElement=Xonomy.xml2js(parameter.toXml(val, jsElement));
-		else jsNewElement=Xonomy.xml2js(val);
+		else if(parameter.toXml) jsNewElement=Xonomy.xml2js(parameter.toXml(val, jsElement), jsElement.parent());
+		else jsNewElement=Xonomy.xml2js(val, jsElement.parent());
 
 		var obj=document.getElementById(htmlID);
 		var html=Xonomy.renderElement(jsNewElement);

--- a/xonomy.js
+++ b/xonomy.js
@@ -184,8 +184,8 @@ Xonomy.asFunction=function(specProperty, defaultValue){
 Xonomy.verifyDocSpecElement=function(name) { //make sure the DocSpec object has such an element, that the element has everything it needs
 	if(!Xonomy.docSpec.elements[name] || typeof(Xonomy.docSpec.elements[name])!="object") {
 		if(Xonomy.docSpec.unknownElement) {
-			Xonomy.docSpec.elements[name]=(typeof(Xonomy.docSpec.unknownElement)==="function") 
-				? Xonomy.docSpec.unknownElement(name) 
+			Xonomy.docSpec.elements[name]=(typeof(Xonomy.docSpec.unknownElement)==="function")
+				? Xonomy.docSpec.unknownElement(name)
 				: Xonomy.docSpec.unknownElement;
 		}
 		else Xonomy.docSpec.elements[name]={};
@@ -749,9 +749,9 @@ Xonomy.click=function(htmlID, what) {
 			if(content!="") {
 				document.body.appendChild(Xonomy.makeBubble(content)); //create bubble
 				Xonomy.showBubble($("#"+htmlID+" > .name")); //anchor bubble to attribute name
-				var surrogateAttr = Xonomy.harvestAttribute(document.getElementById(htmlID));
-				$("#"+htmlID).trigger("xonomy-click-attribute", [surrogateAttr]);
 			}
+			var surrogateAttr = Xonomy.harvestAttribute(document.getElementById(htmlID));
+			$("#"+htmlID).trigger("xonomy-click-attribute", [surrogateAttr]);
 		}
 		if(!isReadOnly && what=="attributeValue") {
 			$("#"+htmlID+" > .valueContainer").addClass("current"); //make attribute value current
@@ -868,7 +868,7 @@ Xonomy.showBubble=function($anchor) {
 		if (offset.top + height + bubbleHeight <= screenHeight) {
 			// enough space - open down
 			top = (offset.top + height) + "px";
-		} else if (screenHeight - offset.top + 5 - bubbleHeight > 0) {
+		} else if (screenHeight - offset.top + 5 + bubbleHeight > 0) {
 			// 5px above for some padding. Anchor using bottom so animation opens upwards.
 			bottom = (screenHeight - offset.top + 5) + "px";
 		} else {
@@ -1167,10 +1167,10 @@ Xonomy.editRaw=function(htmlID, parameter) {
 
 Xonomy.draggingID=null; //what are we dragging?
 Xonomy.drag=function(ev) { //called when dragging starts
-	// Wrapping all the code into a timeout handler is a workaround for a Chrome browser bug 
+	// Wrapping all the code into a timeout handler is a workaround for a Chrome browser bug
 	// (if the DOM is manipulated in the 'dragStart' event then 'dragEnd' event is sometimes fired immediately)
 	//
-	// for more details @see: 
+	// for more details @see:
 	//   http://stackoverflow.com/questions/19639969/html5-dragend-event-firing-immediately
 	var htmlID=ev.target.parentNode.parentNode.id;
 	ev.dataTransfer.setData("text", htmlID);

--- a/xonomy.js
+++ b/xonomy.js
@@ -852,30 +852,30 @@ Xonomy.showBubble=function($anchor) {
 	var bubbleHeight = $bubble.outerHeight();
 	var width = $anchor.width(); if (width > 40) width = 40;
 	var height = $anchor.height(); if (height > 25) height = 25;
-    var placement;
+	if (Xonomy.mode == "laic") { width = width - 25; height = height + 10; }
 
-    function verticalPlacement() {
-        var top = "";
-        var bottom = ""; 
-		if (screenHeight>0 && offset.top + height + bubbleHeight > screenHeight) { // not enough room, open up
-            // 5px above for some padding. Anchor using bottom so animation opens upwards.
-			bottom = (screenHeight - offset.top + 5) + "px"; 
-		} else {
+	function verticalPlacement() {
+		var top = "";
+		var bottom = "";
+		if (offset.top + height + bubbleHeight <= screenHeight) {
+			// enough space - open down
 			top = (offset.top + height) + "px";
+		} else if (screenHeight - offset.top + 5 - bubbleHeight > 0) {
+			// 5px above for some padding. Anchor using bottom so animation opens upwards.
+			bottom = (screenHeight - offset.top + 5) + "px";
+		} else {
+			// neither downwards nor upwards is enough space => center the bubble
+			top = (screenHeight - bubbleHeight)/2 + "px";
 		}
-        return { top: top, bottom: bottom };
-    }
+		return { top: top, bottom: bottom };
+	}
 
-
+	var placement = verticalPlacement();
 	if(offset.left<screenWidth/2) {
-		if (Xonomy.mode == "laic") { width = width - 25; height = height + 10; }
-        placement = verticalPlacement();
-        placement.left = (offset.left + width - 15) + "px";
+		placement.left = (offset.left + width - 15) + "px";
 	} else {
-		if(Xonomy.mode=="laic") { height=height+10; }
 		$bubble.addClass("rightAnchored");
-        placement = verticalPlacement();
-        placement.right = (screenWidth - offset.left) + "px";
+		placement.right = (screenWidth - offset.left) + "px";
 	}
 	$bubble.css(placement);
 	$bubble.slideDown("fast", function() {

--- a/xonomy.js
+++ b/xonomy.js
@@ -1065,9 +1065,9 @@ Xonomy.newElementChild=function(htmlID, parameter) {
 	var $html=$(html).hide();
 	$("#"+htmlID+" > .children").append($html);
 	Xonomy.plusminus(htmlID, true);
+	Xonomy.elementReorder($html.attr("id"));
 	Xonomy.changed();
 	$html.fadeIn();
-	Xonomy.elementReorder($html.attr("id"));
 };
 Xonomy.elementReorder=function(htmlID){
 	var that=document.getElementById(htmlID);

--- a/xonomy.js
+++ b/xonomy.js
@@ -1149,71 +1149,78 @@ Xonomy.editRaw=function(htmlID, parameter) {
 
 Xonomy.draggingID=null; //what are we dragging?
 Xonomy.drag=function(ev) { //called when dragging starts
-	Xonomy.clickoff();
+	// Wrapping all the code into a timeout handler is a workaround for a Chrome browser bug 
+	// (if the DOM is manipulated in the 'dragStart' event then 'dragEnd' event is sometimes fired immediately)
+	//
+	// for more details @see: 
+	//   http://stackoverflow.com/questions/19639969/html5-dragend-event-firing-immediately
 	var htmlID=ev.target.parentNode.parentNode.id;
-	var $element=$("#"+htmlID);
-	var elementName=$element.attr("data-name");
-	var elSpec=Xonomy.docSpec.elements[elementName];
-	$element.addClass("dragging");
-	$(".xonomy .children").append("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
-	$(".xonomy .children .element").before("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
-	$(".xonomy .children .text").before("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
-	$(".xonomy .dragging .elementDropper").remove(); //remove drop targets fom inside the element being dragged
-	$(".xonomy .dragging").prev(".elementDropper").remove(); //remove drop targets from immediately before the element being dragged
-	$(".xonomy .dragging").next(".elementDropper").remove(); //remove drop targets from immediately after the element being dragged
-	$(".xonomy .element.readonly .elementDropper").remove(); //remove drop targets from inside read-only elements
-	if(elSpec.localDropOnly(Xonomy.harvest(htmlID))) {
-		if(elSpec.canDropTo) { //remove the drop target from elements that are not the dragged element's parent
+	ev.dataTransfer.setData("text", htmlID);
+	setTimeout(function() {
+		Xonomy.clickoff();
+		var $element=$("#"+htmlID);
+		var elementName=$element.attr("data-name");
+		var elSpec=Xonomy.docSpec.elements[elementName];
+		$element.addClass("dragging");
+		$(".xonomy .children").append("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
+		$(".xonomy .children .element").before("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
+		$(".xonomy .children .text").before("<div class='elementDropper' ondragover='Xonomy.dragOver(event)' ondragleave='Xonomy.dragOut(event)' ondrop='Xonomy.drop(event)'><div class='inside'></div></div>")
+		$(".xonomy .dragging .elementDropper").remove(); //remove drop targets fom inside the element being dragged
+		$(".xonomy .dragging").prev(".elementDropper").remove(); //remove drop targets from immediately before the element being dragged
+		$(".xonomy .dragging").next(".elementDropper").remove(); //remove drop targets from immediately after the element being dragged
+		$(".xonomy .element.readonly .elementDropper").remove(); //remove drop targets from inside read-only elements
+		if(elSpec.localDropOnly(Xonomy.harvest(htmlID))) {
+			if(elSpec.canDropTo) { //remove the drop target from elements that are not the dragged element's parent
+				var droppers=$(".xonomy .elementDropper").toArray();
+				for(var i=0; i<droppers.length; i++) {
+					var dropper=droppers[i];
+					if(dropper.parentNode!=ev.target.parentNode.parentNode.parentNode) {
+						dropper.parentNode.removeChild(dropper);
+					}
+				}
+			}
+		}
+		if(elSpec.canDropTo) { //remove the drop target from elements it cannot be dropped into
 			var droppers=$(".xonomy .elementDropper").toArray();
 			for(var i=0; i<droppers.length; i++) {
 				var dropper=droppers[i];
-				if(dropper.parentNode!=ev.target.parentNode.parentNode.parentNode) {
+				var parentElementName=$(dropper.parentNode.parentNode).toArray()[0].getAttribute("data-name");
+				if($.inArray(parentElementName, elSpec.canDropTo)<0) {
 					dropper.parentNode.removeChild(dropper);
 				}
 			}
 		}
-	}
-	if(elSpec.canDropTo) { //remove the drop target from elements it cannot be dropped into
-		var droppers=$(".xonomy .elementDropper").toArray();
-		for(var i=0; i<droppers.length; i++) {
-			var dropper=droppers[i];
-			var parentElementName=$(dropper.parentNode.parentNode).toArray()[0].getAttribute("data-name");
-			if($.inArray(parentElementName, elSpec.canDropTo)<0) {
-				dropper.parentNode.removeChild(dropper);
-			}
-		}
-	}
-	if(elSpec.mustBeBefore) { //remove the drop target from after elements it cannot be after
-		var jsElement=Xonomy.harvestElement($element.toArray()[0]);
-		var droppers=$(".xonomy .elementDropper").toArray();
-		for(var i=0; i<droppers.length; i++) {
-			var dropper=droppers[i];
-			jsElement.internalParent=Xonomy.harvestElement(dropper.parentNode.parentNode); //pretend the element's parent is the dropper's parent
-			var mustBeBefore=elSpec.mustBeBefore(jsElement);
-			for(var ii=0; ii<mustBeBefore.length; ii++) {
-				if( $(dropper).prevAll("*[data-name='"+mustBeBefore[ii]+"']").toArray().length>0 ) {
-					dropper.parentNode.removeChild(dropper);
+		if(elSpec.mustBeBefore) { //remove the drop target from after elements it cannot be after
+			var jsElement=Xonomy.harvestElement($element.toArray()[0]);
+			var droppers=$(".xonomy .elementDropper").toArray();
+			for(var i=0; i<droppers.length; i++) {
+				var dropper=droppers[i];
+				jsElement.internalParent=Xonomy.harvestElement(dropper.parentNode.parentNode); //pretend the element's parent is the dropper's parent
+				var mustBeBefore=elSpec.mustBeBefore(jsElement);
+				for(var ii=0; ii<mustBeBefore.length; ii++) {
+					if( $(dropper).prevAll("*[data-name='"+mustBeBefore[ii]+"']").toArray().length>0 ) {
+						dropper.parentNode.removeChild(dropper);
+					}
 				}
 			}
 		}
-	}
-	if(elSpec.mustBeAfter) { //remove the drop target from before elements it cannot be before
-		var jsElement=Xonomy.harvestElement($element.toArray()[0]);
-		var droppers=$(".xonomy .elementDropper").toArray();
-		for(var i=0; i<droppers.length; i++) {
-			var dropper=droppers[i];
-			jsElement.internalParent=Xonomy.harvestElement(dropper.parentNode.parentNode); //pretend the element's parent is the dropper's parent
-			var mustBeAfter=elSpec.mustBeAfter(jsElement);
-			for(var ii=0; ii<mustBeAfter.length; ii++) {
-				if( $(dropper).nextAll("*[data-name='"+mustBeAfter[ii]+"']").toArray().length>0 ) {
-					dropper.parentNode.removeChild(dropper);
+		if(elSpec.mustBeAfter) { //remove the drop target from before elements it cannot be before
+			var jsElement=Xonomy.harvestElement($element.toArray()[0]);
+			var droppers=$(".xonomy .elementDropper").toArray();
+			for(var i=0; i<droppers.length; i++) {
+				var dropper=droppers[i];
+				jsElement.internalParent=Xonomy.harvestElement(dropper.parentNode.parentNode); //pretend the element's parent is the dropper's parent
+				var mustBeAfter=elSpec.mustBeAfter(jsElement);
+				for(var ii=0; ii<mustBeAfter.length; ii++) {
+					if( $(dropper).nextAll("*[data-name='"+mustBeAfter[ii]+"']").toArray().length>0 ) {
+						dropper.parentNode.removeChild(dropper);
+					}
 				}
 			}
 		}
-	}
-	Xonomy.draggingID=htmlID;
-	ev.dataTransfer.setData("text", htmlID);
-	Xonomy.refresh();
+		Xonomy.draggingID=htmlID;
+		Xonomy.refresh();
+	}, 10);
 };
 Xonomy.dragOver=function(ev) {
 	ev.preventDefault();

--- a/xonomy.js
+++ b/xonomy.js
@@ -848,13 +848,13 @@ Xonomy.showBubble=function($anchor) {
 	var $bubble=$("#xonomyBubble");
 	var offset=$anchor.offset(); var left=offset.left; var top=offset.top;
 	var screenWidth = $("body").width();
-	var screenHeight = $(window).height();
+	var screenHeight = $(document).height();
 	var bubbleHeight = $bubble.outerHeight();
 	var width = $anchor.width(); if (width > 40) width = 40;
 	var height = $anchor.height(); if (height > 25) height = 25;
 	if(left<screenWidth/2) {
 		if (Xonomy.mode == "laic") { width = width - 25; height = height + 10; }
-		if (top + height + bubbleHeight > screenHeight) { // not enough room, open up
+		if (screenHeight>0 && top + height + bubbleHeight > screenHeight) { // not enough room, open up
 			$bubble.css({ top: "", bottom: (screenHeight - top + 5) + "px", left: (left + width - 15) + "px" }); // 5px above for some padding. Anchor using bottom so animation opens upwards.
 		} else {
 			$bubble.css({ top: (top + height) + "px", bottom: "", left: (left + width - 15) + "px" });

--- a/xonomy.js
+++ b/xonomy.js
@@ -183,7 +183,11 @@ Xonomy.asFunction=function(specProperty, defaultValue){
 }
 Xonomy.verifyDocSpecElement=function(name) { //make sure the DocSpec object has such an element, that the element has everything it needs
 	if(!Xonomy.docSpec.elements[name] || typeof(Xonomy.docSpec.elements[name])!="object") {
-		if(Xonomy.docSpec.unknownElement) Xonomy.docSpec.elements[name]=Xonomy.docSpec.unknownElement;
+		if(Xonomy.docSpec.unknownElement) {
+			Xonomy.docSpec.elements[name]=(typeof(Xonomy.docSpec.unknownElement)==="function") 
+				? Xonomy.docSpec.unknownElement(name) 
+				: Xonomy.docSpec.unknownElement;
+		}
 		else Xonomy.docSpec.elements[name]={};
 	}
 	var spec=Xonomy.docSpec.elements[name];
@@ -211,7 +215,11 @@ Xonomy.verifyDocSpecElement=function(name) { //make sure the DocSpec object has 
 Xonomy.verifyDocSpecAttribute=function(elementName, attributeName) { //make sure the DocSpec object has such an attribute, that the attribute has everything it needs
 	var elSpec=Xonomy.docSpec.elements[elementName];
 	if(!elSpec.attributes[attributeName] || typeof(elSpec.attributes[attributeName])!="object") {
-		if(Xonomy.docSpec.unknownAttribute) elSpec.attributes[attributeName]=Xonomy.docSpec.unknownAttribute;
+		if(Xonomy.docSpec.unknownAttribute) {
+			elSpec.attributes[attributeName]=(typeof(Xonomy.docSpec.unknownAttribute)==="function")
+				? Xonomy.docSpec.unknownAttribute(elementName, attributeName)
+				: Xonomy.docSpec.unknownAttribute;
+		}
 		else elSpec.attributes[attributeName]={};
 	}
 	var spec=elSpec.attributes[attributeName];

--- a/xonomy.js
+++ b/xonomy.js
@@ -846,28 +846,38 @@ Xonomy.makeBubble=function(content) {
 };
 Xonomy.showBubble=function($anchor) {
 	var $bubble=$("#xonomyBubble");
-	var offset=$anchor.offset(); var left=offset.left; var top=offset.top;
+	var offset=$anchor.offset();
 	var screenWidth = $("body").width();
 	var screenHeight = $(document).height();
 	var bubbleHeight = $bubble.outerHeight();
 	var width = $anchor.width(); if (width > 40) width = 40;
 	var height = $anchor.height(); if (height > 25) height = 25;
-	if(left<screenWidth/2) {
-		if (Xonomy.mode == "laic") { width = width - 25; height = height + 10; }
-		if (screenHeight>0 && top + height + bubbleHeight > screenHeight) { // not enough room, open up
-			$bubble.css({ top: "", bottom: (screenHeight - top + 5) + "px", left: (left + width - 15) + "px" }); // 5px above for some padding. Anchor using bottom so animation opens upwards.
+    var placement;
+
+    function verticalPlacement() {
+        var top = "";
+        var bottom = ""; 
+		if (screenHeight>0 && offset.top + height + bubbleHeight > screenHeight) { // not enough room, open up
+            // 5px above for some padding. Anchor using bottom so animation opens upwards.
+			bottom = (screenHeight - offset.top + 5) + "px"; 
 		} else {
-			$bubble.css({ top: (top + height) + "px", bottom: "", left: (left + width - 15) + "px" });
+			top = (offset.top + height) + "px";
 		}
+        return { top: top, bottom: bottom };
+    }
+
+
+	if(offset.left<screenWidth/2) {
+		if (Xonomy.mode == "laic") { width = width - 25; height = height + 10; }
+        placement = verticalPlacement();
+        placement.left = (offset.left + width - 15) + "px";
 	} else {
 		if(Xonomy.mode=="laic") { height=height+10; }
 		$bubble.addClass("rightAnchored");
-		if (top + height + bubbleHeight > screenHeight) { // not enough room, open up
-			$bubble.css({ top: "", bottom: (screenHeight - top + 5) + "px", right: (screenWidth - left) + "px" }); // 5px above for some padding. Anchor using bottom so animation opens upwards.
-		} else {
-			$bubble.css({ top: (top + height) + "px", bottom: "", right: (screenWidth - left) + "px" });
-		}
+        placement = verticalPlacement();
+        placement.right = (screenWidth - offset.left) + "px";
 	}
+	$bubble.css(placement);
 	$bubble.slideDown("fast", function() {
 		$bubble.find(".focusme").first().focus(); //if the context menu contains anything with the class name 'focusme', focus it.
 	});

--- a/xonomy.js
+++ b/xonomy.js
@@ -964,60 +964,48 @@ Xonomy.wyc=function(url, callback){ //a "when-you-can" function for delayed rend
 	return "<span class='wyc' id='"+wycID+"'></span>";
 };
 
+Xonomy.internalMenu=function(htmlID, items, harvest, getter) {
+	var fragments = items.map(function (item, i) {
+		Xonomy.verifyDocSpecMenuItem(item);
+		var jsMe=harvest(document.getElementById(htmlID));
+		var includeIt=!item.hideIf(jsMe);
+		var html="";
+		if(includeIt) {
+			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction("+getter(i)+", \""+htmlID+"\")'>";
+			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
+			html+="</div>";
+			}
+		return html;
+		});
+	return fragments.length
+		? "<div class='menu'>"+fragments.join("")+"</div>"
+		: "";
+};
 Xonomy.attributeMenu=function(htmlID) {
 	var name=$("#"+htmlID).attr("data-name"); //obtain attribute's name
 	var elName=$("#"+htmlID).closest(".element").attr("data-name"); //obtain element's name
 	Xonomy.verifyDocSpecAttribute(elName, name);
 	var spec=Xonomy.docSpec.elements[elName].attributes[name];
-	var html="";
-	for(var i=0; i<spec.menu.length; i++) {
-		var item=spec.menu[i];
-		Xonomy.verifyDocSpecMenuItem(item);
-		var jsMe=Xonomy.harvestAttribute(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(jsMe);
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].attributes[\""+name+"\"].menu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].attributes["'+name+'"].menu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.menu, Xonomy.harvestAttribute, getter);
 };
 Xonomy.elementMenu=function(htmlID) {
 	var elName=$("#"+htmlID).attr("data-name"); //obtain element's name
 	var spec=Xonomy.docSpec.elements[elName];
-	var html="";
-	for(var i=0; i<spec.menu.length; i++) {
-		var item=spec.menu[i];
-		Xonomy.verifyDocSpecMenuItem(item);
-		var jsMe=Xonomy.harvestElement(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(jsMe);
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].menu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].menu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.menu, Xonomy.harvestElement, getter);
 };
 Xonomy.inlineMenu=function(htmlID) {
 	var elName=$("#"+htmlID).attr("data-name"); //obtain element's name
 	var spec=Xonomy.docSpec.elements[elName];
-	var html="";
-	for(var i=0; i<spec.inlineMenu.length; i++) {
-		var item=spec.inlineMenu[i];
-		var jsMe=Xonomy.harvestElement(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(Xonomy.harvestElement(document.getElementById(htmlID)));
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].inlineMenu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].inlineMenu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.inlineMenu, Xonomy.harvestElement, getter);
 };
 Xonomy.callMenuFunction=function(menuItem, htmlID) {
 	menuItem.action(htmlID, menuItem.actionParameter);


### PR DESCRIPTION
There are cases when full element hierarchy (including top-level parent) is necessary for proper element rendering.

Consider the following configuration:
  ```
var docSpec = {
    elements: {
      item: {
        collapsed: function(jsElement) {
          return js.parent().name === 'document';
        }
      },
      ...
    }
  };
```

In such case it is crucial to construct `jsElement` including the parent element, otherwise the user-defined `collapsed` function fails.

Please, note that this change can have a significant performance hit of harvesting parent element even if it is not necessary. Alternatively we could consider a lazy approach - modify the `Xonomy.xml2js()` to accept `parent` argument as a function. 

Then instead of this:
  ```
var jsParent = Xonomy.harvestElement(document.getElementById(htmlID));
  html+=Xonomy.renderElement(Xonomy.xml2js(xml, jsParent));
```
... we could call it as follows:
  ```
function parent() {
    return Xonomy.harvestElement(document.getElementById(htmlID));
  }
  html+=Xonomy.renderElement(Xonomy.xml2js(xml, parent));
```